### PR TITLE
Improves image load 

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -37,8 +37,8 @@ def main(argv) -> None:
 
   # Load images.
   print("> Loading images...")
-  image0 = np.array(Image.open(argv[1]))
-  image1 = np.array(Image.open(argv[2]))
+  image0 = np.array(Image.open(argv[1]).convert("RGB"))
+  image1 = np.array(Image.open(argv[2]).convert("RGB"))
 
   # Load models.
   print("> Loading OmniGlue (and its submodules: SuperPoint & DINOv2)...")


### PR DESCRIPTION
Thank you for providing the source code for this interesting task,
I suggest a minor code correction.

In the existing code, the following error occurs when an image of the RGBA type comes in.
```
ValueError                                Traceback (most recent call last)
Cell In[47], [line 19](vscode-notebook-cell:?execution_count=47&line=19)
     [17](vscode-notebook-cell:?execution_count=47&line=17) print("> Finding matches...")
     [18](vscode-notebook-cell:?execution_count=47&line=18) start = time.time()
---> [19](vscode-notebook-cell:?execution_count=47&line=19) match_kp0, match_kp1, match_confidences = og.FindMatches(img0, img1)
     [20](vscode-notebook-cell:?execution_count=47&line=20) num_matches = match_kp0.shape[0]
     [21](vscode-notebook-cell:?execution_count=47&line=21) print(f"> \tFound {num_matches} matches.")

File [~/ML/floor-plan-matching/src/omniglue/src/omniglue/omniglue_extract.py:48](omniglue/src/omniglue/omniglue_extract.py:48), in OmniGlue.FindMatches(self, image0, image1)
     [46](~/omniglue/src/omniglue/omniglue_extract.py:46) sp_features0 = self.sp_extract(image0)
     [47](~/omniglue/src/omniglue/omniglue_extract.py:47) sp_features1 = self.sp_extract(image1)
---> [48](~/omniglue/src/omniglue/omniglue_extract.py:48) dino_features0 = self.dino_extract(image0)
     [49](~/omniglue/src/omniglue/omniglue_extract.py:49) dino_features1 = self.dino_extract(image1)
     [50](~/omniglue/src/omniglue/omniglue_extract.py:50) dino_descriptors0 = dino_extract.get_dino_descriptors(
     [51](~/omniglue/src/omniglue/omniglue_extract.py:51)     dino_features0,
     [52](~/omniglue/src/omniglue/omniglue_extract.py:52)     tf.convert_to_tensor(sp_features0[0], dtype=tf.float32),
   (...)
     [55](~/omniglue/src/omniglue/omniglue_extract.py:55)     DINO_FEATURE_DIM,
     [56](~/omniglue/src/omniglue/omniglue_extract.py:56) )

File [~/ML/floor-plan-matching/src/omniglue/src/omniglue/dino_extract.py:46](~/omniglue/src/omniglue/dino_extract.py:46), in DINOExtract.__call__(self, image)
     [45](~/omniglue/src/omniglue/dino_extract.py:45) def __call__(self, image) -> np.ndarray:
---> [46](~/omniglue/src/omniglue/dino_extract.py:46)   return self.forward(image)
...
---> [99](~/omniglue/src/omniglue/dino_extract.py:99) image_processed = (image_processed - mean) [/](https://vscode-remote+ssh-002dremote-002b7b22686f73744e616d65223a2264616e6e792d52545834303930227d.vscode-resource.vscode-cdn.net/) std
    [100](~/omniglue/src/omniglue/dino_extract.py:100) image_processed = torch.from_numpy(image_processed).permute(2, 0, 1)
    [101](~/omniglue/src/omniglue/dino_extract.py:101) return image_processed

ValueError: operands could not be broadcast together with shapes (462,630,4) (3,)
```
It seems to be a problem with the input image channel.
If you change it as below, the Grayscale Image or Image with alpha channel can also be converted to RGB for flexible use.


